### PR TITLE
Updated Ping Flag

### DIFF
--- a/sample-mfg/simulate-mfg.sh
+++ b/sample-mfg/simulate-mfg.sh
@@ -196,7 +196,7 @@ fi
 # Ensure RV hostname is resolvable and pingable
 rvHost=${rvUrl#http*://}   # strip protocol
 rvHost=${rvHost%:*}   # strip optional port
-if ! ping -c 1 -w 5 $rvHost > /dev/null 2>&1 ; then
+if ! ping -c 1 -W 5 $rvHost > /dev/null 2>&1 ; then
     echo "Error: host $rvHost is not resolvable or pingable"
     exit 1
 fi


### PR DESCRIPTION
The wait time flag when running the if statement `if ! ping -c 1 -w 5 $rvHost > /dev/null 2>&1 ; then` should this be capitalized? Once I made the change `if ! ping -c 1 -W 5 $rvHost > /dev/null 2>&1 ; then` my host was able to be reached. I also tested it against a false host and it gave the error message like it is supposed to.