### PR TITLE
fixed some http status codes returned by some APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and sdo-owner-services (for now they use the samme version number)
-export VERSION ?= 1.11.6
+export VERSION ?= 1.11.7
 # used by sample-mfg/Makefile. Needs to match what is in sdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
 SDO_VERSION ?= 1.10.1
 STABLE_VERSION ?= 1.11

--- a/README-1.10.md
+++ b/README-1.10.md
@@ -71,16 +71,26 @@ Before continuing with the rest of the SDO process, it is good to verify that yo
 
 For production use of SDO, you need to create 3 key pairs and import them into the owner services container. These key pairs enable you to securely take over ownership of SDO ownership vouchers from SDO-enabled device manufacturers, and to securely configure your booting SDO devices. Use the provided API to easily create and import the necessary key pairs. (If you are only trying out SDO in a dev/test environment, you can use the built-in sample key pairs and skip this section. You can always add your own key pairs later.)
 
-Note: you only have to perform the steps in this section once. The keys create and import can be used with all of your devices.
+Note: you only have to perform the steps in this section once. The keys created and imported can be used with all of your devices.
 
-1. Now **on your admin host** go to the directory where you want your owner public keys to be saved. Run the API call below to import your user information json in order to generate and import key pairs into the SDO owner services.
+1. **On your admin host** go to the directory where you want your owner public keys to be saved. Run the commands below (modifying the key information as desired) to create the key pairs in the SDO owner service and receive the corresponding public keys:
 
    ```bash
-   curl -sS -w "%{http_code}" -u "$HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH" -X POST -H Content-Type:application/json -d @ren.json -o "${HZN_ORG_ID}_${KEY_NAME}_public-key.pem" $HZN_SDO_SVC_URL/keys && echo
+   cat > key-info.json << EndOfText 
+   {
+     "key_name": "mykey",
+     "common_name": "My Full Name",
+     "email_name": "my@email.com",
+     "company_name": "My Company",
+     "country_name": "My Country",
+     "state_name": "My StateOrProvince",
+     "locale_name":"My City"
+   }
+   EndOfText
+   curl -sS -w "%{http_code}" -u "$HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH" -X POST -H Content-Type:application/json -d @key-info.json -o "${HZN_ORG_ID}_${KEY_NAME}_public-key.pem" $HZN_SDO_SVC_URL/keys && echo
    ```  
 
-2. One file is returned as a result of this API call:
-   - `${HZN_ORG_ID}_${KEY_NAME}_public-key.pem`: The customer/owner public keys (all in a single file) corresponding to the private key pairs that were imported into SDO owner services. This is used by the device manufacturer to securely extend the vouchers to the owner. Pass this file as an argument whenever running simulate-mfg.sh, and give this public key to each device manufacturer producing SDO-enabled devices for you.
+2. One file is returned as a result of this API: `${HZN_ORG_ID}_${KEY_NAME}_public-key.pem` . This is your customer/owner public keys (all in a single file) corresponding to the private key pairs that were imported into the SDO owner service. This is used by the device manufacturer to securely extend the vouchers to the owner. Pass this file as an argument to `simulate-mfg.sh` when experimenting with SDO, and give this public key to each device manufacturer producing SDO-enabled devices for you.
     
 
 ### <a name="init-device"></a>Initialize a Test VM Device with SDO

--- a/docs/ocs-api-swagger.yaml
+++ b/docs/ocs-api-swagger.yaml
@@ -115,12 +115,12 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Voucher'
-        '400':
-          description: Invalid voucher id
         '401':
           description: Invalid credentials
         '403':
           description: Permission denied
+        '404':
+          description: Voucher not found
   /orgs/{org-id}/keys:
     get:
       tags:
@@ -145,6 +145,8 @@ paths:
           description: Invalid credentials
         '403':
           description: Permission denied
+        '404':
+          description: Not found
     post:
       tags:
         - keys
@@ -205,12 +207,12 @@ paths:
           description: Successful. The public keys are returned, concatenated together.
           schema:
             $ref: '#/definitions/PublicKeyFile'
-        '400':
-          description: Invalid key name
         '401':
           description: Invalid credentials
         '403':
           description: Permission denied
+        '404':
+          description: Key name not found
     delete:
       tags:
         - keys
@@ -232,11 +234,13 @@ paths:
         '204':
           description: successful operation
         '400':
-          description: Invalid key name
+          description: Invalid request
         '401':
           description: Invalid credentials
         '403':
           description: Permission denied
+        '404':
+          description: Key name not found
 definitions:
   Version:
     type: string

--- a/ocs-api/main.go
+++ b/ocs-api/main.go
@@ -148,7 +148,7 @@ func getVoucherHandler(orgId, deviceUuid string, w http.ResponseWriter, r *http.
 	voucherFileName := OcsDbDir + "/v1/devices/" + deviceUuid + "/voucher.json"
 	voucherBytes, err := ioutil.ReadFile(filepath.Clean(voucherFileName))
 	if err != nil {
-		http.Error(w, "Error reading "+voucherFileName+": "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "Error reading "+voucherFileName+": "+err.Error(), http.StatusNotFound)
 		return
 	}
 
@@ -160,7 +160,7 @@ func getVoucherHandler(orgId, deviceUuid string, w http.ResponseWriter, r *http.
 		return
 	}
 	if orgidTxtStr != deviceOrgId { // this device is in our org
-		http.Error(w, "Device "+deviceUuid+" is not in org "+deviceOrgId, http.StatusBadRequest)
+		http.Error(w, "Device "+deviceUuid+" is not in org "+deviceOrgId, http.StatusForbidden)
 		return
 	}
 
@@ -193,7 +193,7 @@ func getVouchersHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	vouchersDirName := OcsDbDir + "/v1/devices"
 	deviceDirs, err := ioutil.ReadDir(filepath.Clean(vouchersDirName))
 	if err != nil {
-		http.Error(w, "Error reading "+vouchersDirName+" directory: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "Error reading "+vouchersDirName+" directory: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -373,7 +373,7 @@ func getKeysHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	stdOut, stdErr, err := outils.RunCmd(outils.RunCmdOpts{}, "./get-owner-key-expirations.sh", deviceOrgId, user)
 	KeyImportLock.RUnlock()
 	if err != nil {
-		http.Error(w, "error running get-owner-key-expirations.sh: "+err.Error(), http.StatusBadRequest) // this includes stdErr
+		http.Error(w, "error running get-owner-key-expirations.sh: "+err.Error(), http.StatusInternalServerError) // this includes stdErr
 		return
 	} else {
 		if len(stdErr) > 0 { // with shell scripts there can be error msgs in stderr even though the exit code was 0
@@ -413,7 +413,7 @@ func getKeysHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	}
 	userDirs, err := ioutil.ReadDir(filepath.Clean(pubKeyDirName))
 	if err != nil {
-		http.Error(w, "Error reading "+pubKeyDirName+" directory: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "Error reading "+pubKeyDirName+" directory: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -433,7 +433,7 @@ func getKeysHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 			uDir := pubKeyDirName + "/" + user
 			keyFiles, err := ioutil.ReadDir(filepath.Clean(uDir))
 			if err != nil {
-				http.Error(w, "Error reading "+uDir+" directory: "+err.Error(), http.StatusBadRequest)
+				http.Error(w, "Error reading "+uDir+" directory: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
 			for _, f := range keyFiles {
@@ -533,7 +533,7 @@ func deleteKeyHandler(orgId, keyName string, w http.ResponseWriter, r *http.Requ
 	pubKeyFileName := pubKeyDirName + "/" + user + "/" + strings.ToLower(deviceOrgId+"_"+keyName) + "_public-key.pem"
 	if !outils.PathExists(pubKeyFileName) {
 		//http.Error(w, "Public key "+keyName+" for user "+user+" not found", http.StatusNotFound)
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
- `GET /api/orgs/{ord-id}/vouchers/{device-id}` and `GET /api/vouchers/{device-id}`
     - When device-id not found, changed http code from `400` to `404`
     - When device-id is not in the client's org, changed http code from `400` to `403`
- `DELETE /api/orgs/{org-id}/keys/{key-name}`
    - When key-name not found, changed http code from `204` to `404`

Signed-off-by: Bruce Potter <bp@us.ibm.com>