### PR TITLE
Issue 130 - adapt Dockerfile for running on openshift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # Do not want this dir copied from the sdo tar file
-sdo/iot-platform-sdk-v1.10.1/ocs/config/db/v1*
+sdo/iot-platform-sdk-v1.10.1/ocs/config/db/v1/creds*
+sdo/iot-platform-sdk-v1.10.1/ocs/config/db/v1/devices*

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ STABLE_VERSION ?= 1.11
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 
-# If you are building with podman you can pass it here
-export DOCKER_OR_PODMAN ?= docker
+# If you are building with a container engine different from docker you can set it here (e.g. podman)
+export CONTAINER_ENGINE ?= docker
 # The crc internal registry will always look like this
 export CRC_REGISTRY ?= default-route-openshift-image-registry.apps-crc.testing
 # When pushing to the crc local registry and using standard configurations, you need to do it in the same namespace where you deploy your workload
@@ -45,14 +45,14 @@ run-ocs-api: ocs-api/ocs-api
 
 # Build the SDO services docker image - see the build environment requirements listed in docker/Dockerfile
 $(SDO_DOCKER_IMAGE): ocs-api/linux/ocs-api
-	- $(DOCKER_OR_PODMAN) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
-	$(DOCKER_OR_PODMAN) build -t $(DOCKER_REGISTRY)/$@:$(VERSION) $(SDO_IMAGE_LABELS) $(DOCKER_OPTS) -f docker/Dockerfile .
+	- $(CONTAINER_ENGINE) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
+	$(CONTAINER_ENGINE) build -t $(DOCKER_REGISTRY)/$@:$(VERSION) $(SDO_IMAGE_LABELS) $(DOCKER_OPTS) -f docker/Dockerfile .
 
 # Run the SDO services docker container
 # If you want to run the image w/o rebuilding: make -W sdo-owner-services -W ocs-api/linux/ocs-api run-sdo-owner-services
 run-$(SDO_DOCKER_IMAGE): $(SDO_DOCKER_IMAGE)
 	: $${HZN_EXCHANGE_URL:?} $${HZN_FSS_CSSURL:?} $${HZN_MGMT_HUB_CERT:?}
-	- $(DOCKER_OR_PODMAN) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
+	- $(CONTAINER_ENGINE) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
 	docker/run-sdo-owner-services.sh $(VERSION)
 
 # Push the SDO services docker image that you are still working on to the registry. This is necessary if you are testing on a different machine than you are building on.
@@ -60,32 +60,35 @@ dev-push-$(SDO_DOCKER_IMAGE):
 	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
 
 # Push the SDO services docker image that you are still working on to the CRC registry. This is necessary if you are testing on a CRC openshift cluster.
+# To login into the CRC internal registry please run:
+# eval $(crc podman-env --root)
+# podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false
 crc-push-$(SDO_DOCKER_IMAGE):
-	$(DOCKER_OR_PODMAN) tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(CRC_REGISTRY)/$(NAMESPACE)/$(SDO_DOCKER_IMAGE):$(VERSION)
-	$(DOCKER_OR_PODMAN) push $(CRC_REGISTRY)/$(NAMESPACE)/$(SDO_DOCKER_IMAGE):$(VERSION)
+	$(CONTAINER_ENGINE) tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(CRC_REGISTRY)/$(NAMESPACE)/$(SDO_DOCKER_IMAGE):$(VERSION)
+	$(CONTAINER_ENGINE) push $(CRC_REGISTRY)/$(NAMESPACE)/$(SDO_DOCKER_IMAGE):$(VERSION)
 
 # Push the SDO services docker image to the registry and tag as testing
 push-$(SDO_DOCKER_IMAGE):
-	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
-	docker tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):testing
-	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):testing
+	$(CONTAINER_ENGINE) push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
+	$(CONTAINER_ENGINE) tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):testing
+	$(CONTAINER_ENGINE) push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):testing
 
 # Push the SDO services docker image to the registry and tag as latest
 publish-$(SDO_DOCKER_IMAGE):
-	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
-	docker tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):latest
-	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):latest
-	docker tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(STABLE_VERSION)
-	docker push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(STABLE_VERSION)
+	$(CONTAINER_ENGINE) push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
+	$(CONTAINER_ENGINE) tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):latest
+	$(CONTAINER_ENGINE) push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):latest
+	$(CONTAINER_ENGINE) tag $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION) $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(STABLE_VERSION)
+	$(CONTAINER_ENGINE) push $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(STABLE_VERSION)
 
 # Use this if you are on a machine where you did not build the image
 pull-$(SDO_DOCKER_IMAGE):
-	docker pull $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
+	$(CONTAINER_ENGINE) pull $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):$(VERSION)
 
 clean:
 	go clean
 	rm -f ocs-api/ocs-api ocs-api/linux/ocs-api
-	- $(DOCKER_OR_PODMAN) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
-	- $(DOCKER_OR_PODMAN) rmi $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):{$(VERSION),latest,$(STABLE_VERSION)} 2> /dev/null || :
+	- $(CONTAINER_ENGINE) rm -f $(SDO_DOCKER_IMAGE) 2> /dev/null || :
+	- $(CONTAINER_ENGINE) rmi $(DOCKER_REGISTRY)/$(SDO_DOCKER_IMAGE):{$(VERSION),latest,$(STABLE_VERSION)} 2> /dev/null || :
 
 .PHONY: default run-ocs-api run-$(SDO_DOCKER_IMAGE) push-$(SDO_DOCKER_IMAGE) publish-$(SDO_DOCKER_IMAGE) promote-$(SDO_DOCKER_IMAGE) pull-$(SDO_DOCKER_IMAGE) clean

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,7 @@ RUN curl -sS -o epel-release-latest-8.noarch.rpm https://dl.fedoraproject.org/pu
     rpm -i /root/epel-release-latest-8.noarch.rpm && \
     microdnf update -y && \
     microdnf install --nodocs -y openssl ca-certificates tar findutils shadow-utils procps openssl-devel haveged && \
-    microdnf clean all && \
-    groupadd -g 1000 sdouser && adduser -u 1000 -g sdouser sdouser
+    microdnf clean all 
 
 # Install openjdk-11-jre. The tar.gz file is 43 MB, unpacked is 124 MB
 # Note: with SDO 1.7, it is necessary to use java 11.0.4 or earlier, because there is an issue with the SDO bouncycastle version and 11.0.5 and above
@@ -64,7 +63,6 @@ RUN curl -sSL -o openjre-11_linux-x64_bin.tar.gz https://github.com/AdoptOpenJDK
 # this doesn't work here, because docker writes /etc/hosts when it starts the container
 #RUN echo "127.0.0.1 RVSDO OwnerSDO" >> /etc/hosts
 
-USER sdouser
 WORKDIR $WORKDIR
 
 # Get the license file
@@ -73,26 +71,33 @@ COPY sdo/NOTICES-v1.10.1/iot-platform-sdk/* /licenses/SDOIotPlatformSDK/
 
 # Get rendezvous files. The rv subdir will be created automatically by COPY
 # Note: need to use uid and gid to be able to build on non-linux hosts
-COPY --chown=1000:1000 sdo/pri-v1.10.1/rendezvous/* $WORKDIR/rv/
+COPY sdo/pri-v1.10.1/rendezvous/* $WORKDIR/rv/
 
 # Get to0scheduler files
-COPY --chown=1000:1000 sdo/iot-platform-sdk-v1.10.1/to0scheduler $WORKDIR/to0scheduler/
+COPY sdo/iot-platform-sdk-v1.10.1/to0scheduler $WORKDIR/to0scheduler/
 
 # Get OCS files
 # Note: we don't want the contents of ocs/config/db, that is excluded in the .dockerignore file
-COPY --chown=1000:1000 sdo/iot-platform-sdk-v1.10.1/ocs $WORKDIR/ocs/
+COPY sdo/iot-platform-sdk-v1.10.1/ocs $WORKDIR/ocs/
 # This is only the default owner private key. It will be moved into ocs/config/db/v1/creds by start-sdo-owner-servic es.sh if they don't specify their own key in run-sdo-owner-services.sh
-COPY --chown=1000:1000 keys/sample-owner-keystore.p12 $WORKDIR/ocs/config/sample-owner-keystore.p12
+COPY keys/sample-owner-keystore.p12 $WORKDIR/ocs/config/sample-owner-keystore.p12
 #This command gives `USER sdouser` the correct permissions for mounting this key inside the container
-RUN touch ocs/config/owner-keystore.p12 && chown sdouser:sdouser ocs/config/owner-keystore.p12
+RUN touch ocs/config/owner-keystore.p12
 # SDO_OCS_DB_PATH is where the named volume will get mounted to. Create the subdirs, and make sure we own everything
-RUN mkdir -p $SDO_OCS_DB_PATH/v1/{creds,devices,values} ocs-api-dir/keys && chown -R 1000:1000 $SDO_OCS_DB_PATH ocs-api-dir
+RUN mkdir -p $SDO_OCS_DB_PATH/v1/{creds,devices,values} ocs-api-dir/keys
 
 # Get OPS files
-COPY --chown=1000:1000 sdo/iot-platform-sdk-v1.10.1/ops $WORKDIR/ops/
+COPY sdo/iot-platform-sdk-v1.10.1/ops $WORKDIR/ops/
 
 # Get our ocs-api binary, startup script, agent-install-wrapper.sh, and keystore scripts
-COPY --chown=1000:1000 ocs-api/linux/ocs-api ocs-api/scripts/*.sh docker/start-sdo-owner-services.sh $WORKDIR/
+COPY ocs-api/linux/ocs-api ocs-api/scripts/*.sh docker/start-sdo-owner-services.sh $WORKDIR/
+
+# Get the script for fixing permissions, to make the container able to run on Openshift
+COPY docker/fix-permissions /usr/local/bin
+# Apply the script for fixing permissions to a few directories
+RUN /usr/local/bin/fix-permissions $WORKDIR && /usr/local/bin/fix-permissions $SDO_OCS_DB_PATH && /usr/local/bin/fix-permissions ocs-api-dir && /usr/local/bin/fix-permissions ocs/config/owner-keystore.p12
+
+USER 1001
 
 # Note: the EXPOSE stmt doesn't actually expose the port, it just serves as documentation about the -p flags docker run should use. We may override these values, so just let docker run set them.
 #EXPOSE 8040  8042  9008

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,11 +41,13 @@ WORKDIR /root
 # To search for rpms (or for what rpms provides a command): http://www.rpm-find.net/linux/RPM/
 # Note: libssl-dev is is required by all the sdo services on ubuntu. I think the equivalent rpm is openssl-devel
 # Note: due to a bug in microdnf, using the --nodocs option causes an exit code of 141: https://github.com/rpm-software-management/microdnf/issues/50
+# sdouser is added to the root group, this is required to let other users in the same group able to change files created by sdouser
 RUN curl -sS -o epel-release-latest-8.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     rpm -i /root/epel-release-latest-8.noarch.rpm && \
     microdnf update -y && \
     microdnf install --nodocs -y openssl ca-certificates tar findutils shadow-utils procps openssl-devel haveged && \
-    microdnf clean all 
+    microdnf clean all && \
+    adduser -u 1000 -g 0 sdouser
 
 # Install openjdk-11-jre. The tar.gz file is 43 MB, unpacked is 124 MB
 # Note: with SDO 1.7, it is necessary to use java 11.0.4 or earlier, because there is an issue with the SDO bouncycastle version and 11.0.5 and above
@@ -81,8 +83,10 @@ COPY sdo/iot-platform-sdk-v1.10.1/to0scheduler $WORKDIR/to0scheduler/
 COPY sdo/iot-platform-sdk-v1.10.1/ocs $WORKDIR/ocs/
 # This is only the default owner private key. It will be moved into ocs/config/db/v1/creds by start-sdo-owner-servic es.sh if they don't specify their own key in run-sdo-owner-services.sh
 COPY keys/sample-owner-keystore.p12 $WORKDIR/ocs/config/sample-owner-keystore.p12
+
 #This command gives `USER sdouser` the correct permissions for mounting this key inside the container
-RUN touch ocs/config/owner-keystore.p12
+RUN touch $WORKDIR/ocs/config/owner-keystore.p12
+
 # SDO_OCS_DB_PATH is where the named volume will get mounted to. Create the subdirs, and make sure we own everything
 RUN mkdir -p $SDO_OCS_DB_PATH/v1/{creds,devices,values} ocs-api-dir/keys
 
@@ -92,11 +96,10 @@ COPY sdo/iot-platform-sdk-v1.10.1/ops $WORKDIR/ops/
 # Get our ocs-api binary, startup script, agent-install-wrapper.sh, and keystore scripts
 COPY ocs-api/linux/ocs-api ocs-api/scripts/*.sh docker/start-sdo-owner-services.sh $WORKDIR/
 
-# Get the script for fixing permissions, to make the container able to run on Openshift
+# Get the script for fixing permissions, to make the container able to run rootless
 COPY docker/fix-permissions /usr/local/bin
-# Apply the script for fixing permissions to a few directories
-RUN /usr/local/bin/fix-permissions $WORKDIR && /usr/local/bin/fix-permissions $SDO_OCS_DB_PATH && /usr/local/bin/fix-permissions ocs-api-dir && /usr/local/bin/fix-permissions ocs/config/owner-keystore.p12
-
+# Apply it 
+RUN /usr/local/bin/fix-permissions $WORKDIR
 USER 1001
 
 # Note: the EXPOSE stmt doesn't actually expose the port, it just serves as documentation about the -p flags docker run should use. We may override these values, so just let docker run set them.

--- a/docker/fix-permissions
+++ b/docker/fix-permissions
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Fix permissions on the given directory to allow group read/write of
+# regular files and execute of directories.
+
+find $1 -exec chgrp 0 {} \;
+find $1 -exec chmod g+rw {} \;
+find $1 -type d -exec chmod g+x {} +


### PR DESCRIPTION
This change contains actually two different things: 
1. change to the Makefile to allow building with container runtimes different from docker
  this is done by passying the env variable CONTAINER_RUNTIME to the make command, for e.g. `CONTAINER_ENGINE=podman VERSION=9.9.9 DOCKER_OPTS=--no-cache make sdo-owner-services`
2. change to the Dockerfile to have a rootless container, which can run easily on openshift
  this is done by adding the sdouser to the root group, and by adjusting all permissions on the container for files and directories inside the sdouser home dir. 

The change has been tested by deploying SDO inside of a [CRC openshift cluster](https://github.com/code-ready/crc) (but it can now run in any k8s distro), and by deploying it with the standard deploy-mgmt-hub. If you deploy it with the mgmt hub, please be sure that you first make a purge of all volumes and redeploy it, otherwise the permissions to the SDO volume applied by previous runs of the mgmt hub will interphere with the ones required by this new setup.

